### PR TITLE
Interrupts

### DIFF
--- a/device/DISCO_F407VG/PowerSensor/PowerSensor.ino
+++ b/device/DISCO_F407VG/PowerSensor/PowerSensor.ino
@@ -247,13 +247,15 @@ void sendADCValue() {
     uint8_t sensor_id = activeSensors[i];
     // add metadata to remaining bits: 2 bytes available with 10b sensor value
     uint16_t level = serialBuffer[i];
+    uint8_t data[2];
     // write the level, write() only writes per byte;
     // First byte: 1 iii aaaa
     // where iii is the sensor id, a are the upper 4 bits of the level
-    Serial.write(((sensor_id & 0x7) << 4) | ((level & 0x3C0) >> 6) | (1 << 7));
+    data[0] = ((sensor_id & 0x7) << 4) | ((level & 0x3C0) >> 6) | (1 << 7);
     // Second byte: 0 m bbbbbb
     // where m is the marker bit, b are the lower 6 bits of the level
-    Serial.write(((sendMarkerNext << 6) | (level & 0x3F)) & ~(1 << 7));
+    data[1] = ((sendMarkerNext << 6) | (level & 0x3F)) & ~(1 << 7);
+    Serial.write(data, sizeof data);
   }
   sendSingleValue = false;
 }


### PR DESCRIPTION
Using interrupts for sending values to host instead of polling.
Also using one Serial.write per sensor value instead of 2; Writing 2 bytes at a time seems optimal for speed.