### PR TITLE
Implement psconfig for new EEPROM layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ INC = -Ihost/include
 LIB = -Lhost/lib -lPowerSensor
 
 # For Discovery F407
-#BOARD =				DISCO_F407VG
-#DEVICE =            STMicroelectronics:stm32:Disco
+#BOARD =			DISCO_F407VG
+#DEVICE =           STMicroelectronics:stm32:Disco
 #FQBN =				$(DEVICE):pnum=$(BOARD),usb=$(USB)
+#OPT =              -p /dev/ttyACM0
 
 # For Black Pill F401CCU6
 BOARD =				BLACKPILL_F401CC
@@ -14,12 +15,6 @@ DEVICE =            STMicroelectronics:stm32:GenF4
 FQBN =				$(DEVICE):pnum=$(BOARD),usb=$(USB),upload_method=dfuMethod
 
 USB =				CDCgen
-
-ifeq ($(OS), Darwin)
-	PORT =			/dev/cu.usbmodem144103
-else
-	PORT =			/dev/ttyACM0
-endif
 
 host/obj/%.o: host/src/%.cc
 	-mkdir -p host/obj
@@ -42,7 +37,7 @@ device::
 	arduino-cli compile -e --fqbn $(FQBN) device/$(BOARD)/PowerSensor
 
 upload:: device
-	arduino-cli upload -p $(PORT) --fqbn $(FQBN) -i device/$(BOARD)/PowerSensor/build/$(subst :,.,$(DEVICE))/PowerSensor.ino.bin
+	arduino-cli upload $(OPT) --fqbn $(FQBN) -i device/$(BOARD)/PowerSensor/build/$(subst :,.,$(DEVICE))/PowerSensor.ino.bin
 
 clean:
 	$(RM) -r host/bin host/lib host/obj device/$(BOARD)/PowerSensor/build

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ host/obj/%.o: host/src/%.cc
 
 all:: lib bin device
 
-bin:: host/bin/test_ps
+bin:: lib host/bin/test_ps host/bin/psconfig
 
 lib: host/obj/PowerSensor.o host/obj/sensors.o
 	-mkdir -p host/lib

--- a/device/BLACKPILL_F401CC/PowerSensor/PowerSensor.ino
+++ b/device/BLACKPILL_F401CC/PowerSensor/PowerSensor.ino
@@ -35,7 +35,6 @@ struct Sensor {
   char type[16];
   float vref;
   float slope;
-  uint8_t pairId;
   bool inUse;
 } __attribute__((packed));
 

--- a/device/BLACKPILL_F401CC/PowerSensor/eeprom.h
+++ b/device/BLACKPILL_F401CC/PowerSensor/eeprom.h
@@ -69,7 +69,7 @@
 #define PAGE_FULL             ((uint8_t)0x80)
 
 /* Variables' number */
-#define NB_OF_VAR             ((uint8_t)0x68)         /* char[16], 2 float, 1 uint8, 1 bool = 26 bytes, times 8 sensors = 208B = 104 half-words.
+#define NB_OF_VAR             ((uint8_t)0x64)         /* char[16], 2 float, 1 bool = 25 bytes, times 8 sensors = 200B = 100 half-words.
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/

--- a/host/include/PowerSensor.hpp
+++ b/host/include/PowerSensor.hpp
@@ -43,13 +43,11 @@ namespace PowerSensor {
       void setType(unsigned int sensorID, const char* type);
       void setVref(unsigned int sensorID, const float vref);
       void setSlope(unsigned int sensorID, const float slope);
-      void setPairId(unsigned int sensorID, const uint8_t pairId);
       void setInUse(unsigned int sensorID, const bool inUse);
 
       void getType(unsigned int sensorID, char* type) const;
       float getVref(unsigned int sensorID) const;
       float getSlope(unsigned int sensorID) const;
-      uint8_t getPairId(unsigned int sensorID) const;
       bool getInUse(unsigned int sensorID) const;
 
     private:
@@ -85,14 +83,12 @@ namespace PowerSensor {
           char type[16];
           float vref;
           float slope;
-          uint8_t pairId;
           bool inUse;
         } __attribute__((packed));
 
         char type[16];
         float vref;
         float slope;
-        uint8_t pairId;
         bool inUse;
         uint16_t level;
         double valueAtLastMeasurement;

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -173,7 +173,6 @@ namespace PowerSensor {
         std::cerr << "Found incompatible sensor pair: current sensor (ID " << 2*pairID << ") is " << (currentSensorActive ? "" : "not ") << "active, while ";
         std::cerr << "voltage sensor (ID " << 2*pairID+1 << ") is " << (voltageSensorActive ? "" : "not ") << "active. ";
         std::cerr << "Please check sensor configuration." << std::endl;
-        exit(1);
       } else {
         sensorPairs[pairID].inUse = false;
       }
@@ -395,22 +394,27 @@ namespace PowerSensor {
 
   void PowerSensor::setType(unsigned int sensorID, const char* type) {
     sensors[sensorID].setType(type);
+    writeSensorsToEEPROM();
   }
 
   void PowerSensor::setVref(unsigned int sensorID, const float vref) {
     sensors[sensorID].setVref(vref);
+    writeSensorsToEEPROM();
   }
 
   void PowerSensor::setSlope(unsigned int sensorID, const float slope) {
     sensors[sensorID].setSlope(slope);
+    writeSensorsToEEPROM();
   }
 
   void PowerSensor::setPairId(unsigned int sensorID, const uint8_t pairId) {
     sensors[sensorID].setPairId(pairId);
+    writeSensorsToEEPROM();
   }
 
   void PowerSensor::setInUse(unsigned int sensorID, const bool inUse) {
     sensors[sensorID].setInUse(inUse);
+    writeSensorsToEEPROM();
   }
 
 } // namespace PowerSensor

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -92,7 +92,7 @@ namespace PowerSensor {
     // opens the file specified by pathname;
     if ((fileDescriptor = open(device, O_RDWR)) < 0)
     {
-      perror("open device");
+      perror(device);
       exit(1);
     }
     // block if an incompatible lock is held by another process;
@@ -145,11 +145,12 @@ namespace PowerSensor {
 
   void PowerSensor::writeSensorsToEEPROM() {
     if (write(fd, "W", 1) != 1) {
-      perror("Write device");
+      perror("write device");
       exit(1);
     }
     for (const Sensor& sensor: sensors) {
       sensor.writeToEEPROM(fd);
+      usleep(10000);
     }
   }
 

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -385,10 +385,6 @@ namespace PowerSensor {
     return sensors[sensorID].slope;
   }
 
-  uint8_t PowerSensor::getPairId(unsigned int sensorID) const {
-    return sensors[sensorID].pairId;
-  }
-
   bool PowerSensor::getInUse(unsigned int sensorID) const {
     return sensors[sensorID].inUse;
   }
@@ -405,11 +401,6 @@ namespace PowerSensor {
 
   void PowerSensor::setSlope(unsigned int sensorID, const float slope) {
     sensors[sensorID].setSlope(slope);
-    writeSensorsToEEPROM();
-  }
-
-  void PowerSensor::setPairId(unsigned int sensorID, const uint8_t pairId) {
-    sensors[sensorID].setPairId(pairId);
     writeSensorsToEEPROM();
   }
 

--- a/host/src/psconfig.cc
+++ b/host/src/psconfig.cc
@@ -38,18 +38,6 @@ void measureSensors(PowerSensor::State &startState, PowerSensor::State &stopStat
 }
 
 
-// void autoCalibrate()
-// {
-//   if (powerSensor->inUse(sensor)) {
-//     PowerSensor::State startState, stopState;
-
-//     powerSensor->setNullLevel(sensor, 0);
-//     measureSensors(startState, stopState);
-//     powerSensor->setNullLevel(sensor, PowerSensor::Watt(startState, stopState, sensor));
-//   }
-// }
-
-
 void print()
 {
   PowerSensor::State startState, stopState;
@@ -96,11 +84,10 @@ void usage(char *argv[])
   std::cerr << "-t sets the sensor type, (valid types TBD)" << std::endl;
   std::cerr << "-v sets the reference voltage level" << std::endl;
   std::cerr << "-n set the slope" << std::endl;
-  // std::cerr << "-a auto-calibrates the null level" << std::endl;  // disabled while psconfig is still WIP
   std::cerr << "-o turns a sensor on (1) or off (0)" << std::endl;
   std::cerr << "-p prints configured values" << std::endl;
-  // std::cerr << "example: " << argv[0] << " -d/dev/ttyACM0 -s0 -tACS712-20 -v12 -a -s1 -tACS712-5 -v3.3 -a -s2 -tACS712-20 -v12 -a -s3 -o -s4 -o -p" << std::endl;
-  // exit(1);
+  std::cerr << "example: " << argv[0] << " -d /dev/ttyACM0 -s 0 -t ACS712-20 -v 1.65 -n 1.0 -o 1 -s 1 -tACS712-5 -v1.7 -p" << std::endl;
+  exit(1);
 }
 
 

--- a/host/src/psconfig.cc
+++ b/host/src/psconfig.cc
@@ -1,0 +1,165 @@
+#include "PowerSensor.hpp"
+
+#include <unistd.h>
+
+#include <cstring>
+#include <iostream>
+#include <memory>
+
+
+std::unique_ptr<PowerSensor::PowerSensor> powerSensor;
+unsigned int sensor = 0;
+
+
+unsigned int selectSensor(unsigned int sensor) {
+  if (sensor >= PowerSensor::MAX_SENSORS) {
+    std::cerr << "Invalid sensor ID: " << sensor << ", max value is " << PowerSensor::MAX_SENSORS - 1 << std::endl;
+  }
+  return sensor;
+}
+
+
+float convertType(const char *arg)
+{
+  if (strcmp(arg, "ACS712-5") == 0 || strcmp(arg, "acs712-5") == 0)
+    return 0.185;
+  else if (strcmp(arg, "ACS712-20") == 0 || strcmp(arg, "acs712-20") == 0)
+    return 0.1;
+  else if (strcmp(arg, "ACS712-30") == 0 || strcmp(arg, "acs712-30") == 0)
+    return 0.66;
+  else
+    return atof(arg);
+}
+
+
+PowerSensor::PowerSensor *checkPowerSensor()
+{
+  if (powerSensor.get() == nullptr)
+    powerSensor = std::unique_ptr<PowerSensor::PowerSensor>(new PowerSensor::PowerSensor("/dev/ttyACM0"));
+
+  return powerSensor.get();
+}
+
+
+void measureSensors(PowerSensor::State &startState, PowerSensor::State &stopState)
+{
+  startState = powerSensor->read();
+  sleep(2);
+  stopState = powerSensor->read();
+}
+
+
+// void autoCalibrate()
+// {
+//   if (powerSensor->inUse(sensor)) {
+//     PowerSensor::State startState, stopState;
+
+//     powerSensor->setNullLevel(sensor, 0);
+//     measureSensors(startState, stopState);
+//     powerSensor->setNullLevel(sensor, PowerSensor::Watt(startState, stopState, sensor));
+//   }
+// }
+
+
+void print()
+{
+  PowerSensor::State startState, stopState;
+
+  measureSensors(startState, stopState);
+
+  char type[16];
+  for (unsigned sensor = 0; sensor < PowerSensor::MAX_SENSORS; sensor++) {
+    powerSensor->getType(sensor, type);
+    std::cout << "sensor: " << sensor << ", "
+      "Pair ID: " << (int) powerSensor->getPairId(sensor) << ", "
+      "type: " << type << ", "
+      "Vref: " << powerSensor->getVref(sensor) << " V, "
+      "Slope: " << powerSensor->getSlope(sensor) << " V/A, " // TODO: is V/A the correct unit?
+      "Status: " << (powerSensor->getInUse(sensor) ? "on" : "off") << std::endl;
+
+    if (sensor % 2 == 1) {
+      unsigned int pair = sensor / 2;
+      std::cout << "Current usage pair " << pair << ": " << Watt(startState, stopState, pair) << " W" << std::endl;
+    }
+  }
+}
+
+
+void usage(char *argv[])
+{
+  std::cerr << "usage: " << argv[0] << " [-h] [-d device] [-s sensor] [-t type] [-v volt] [-a | -n nullLevel] [-o] [-p]" << std::endl;
+  std::cerr << "-h prints this help" << std::endl;
+  std::cerr << "-d selects the device (default: /dev/ttyACM0)" << std::endl;
+  std::cerr << "-s selects the sensor (0-" << PowerSensor::MAX_SENSORS << ")" << std::endl;
+  std::cerr << "-i sets the sensor pair (0-" << PowerSensor::MAX_PAIRS << ")" << std::endl;
+  std::cerr << "-t sets the sensor type, (valid types TBD)" << std::endl;
+  std::cerr << "-v sets the reference voltage level" << std::endl;
+  std::cerr << "-n set the slope" << std::endl;
+  // std::cerr << "-a auto-calibrates the null level" << std::endl;  // disabled while psconfig is still WIP
+  std::cerr << "-o turns a sensor on (1) or off (0)" << std::endl;
+  std::cerr << "-p prints configured values" << std::endl;
+  // std::cerr << "example: " << argv[0] << " -d/dev/ttyACM0 -s0 -tACS712-20 -v12 -a -s1 -tACS712-5 -v3.3 -a -s2 -tACS712-20 -v12 -a -s3 -o -s4 -o -p" << std::endl;
+  // exit(1);
+}
+
+
+int main(int argc, char *argv[])
+{
+  for (int opt; (opt = getopt(argc, argv, "d:s:i:t:v:n:o:ph")) >= 0;) {
+    switch (opt) {
+      // device select
+      case 'd':
+        powerSensor = std::unique_ptr<PowerSensor::PowerSensor>(new PowerSensor::PowerSensor(optarg));
+    		break;
+
+      // sensor select
+      case 's':
+        sensor = selectSensor((unsigned) atoi(optarg));
+        break;
+
+      // sensor pair
+      case 'i':
+        checkPowerSensor()->setPairId(sensor, atoi(optarg));
+        break;
+
+      // sensor type
+      case 't':
+        checkPowerSensor()->setType(sensor, optarg);
+        break;
+
+      // sensor reference voltage
+      case 'v':
+        checkPowerSensor()->setVref(sensor, atof(optarg));
+        break;
+
+      // sensor slope
+      case 'n':
+        checkPowerSensor()->setSlope(sensor, atof(optarg));
+        break;
+
+      // sensor on/off
+      case 'o':
+        checkPowerSensor()->setInUse(sensor, bool(optarg));
+        break;
+
+      // print
+      case 'p':
+        print();
+        break;
+
+      // help
+      case 'h':
+        usage(argv);
+        break;
+
+      default:
+        usage(argv);
+        break;
+    }
+  }
+
+  if ((optind < argc) || (argc < 2))
+    usage(argv);
+
+  return 0;
+}

--- a/host/src/psconfig.cc
+++ b/host/src/psconfig.cc
@@ -19,19 +19,6 @@ unsigned int selectSensor(unsigned int sensor) {
 }
 
 
-float convertType(const char *arg)
-{
-  if (strcmp(arg, "ACS712-5") == 0 || strcmp(arg, "acs712-5") == 0)
-    return 0.185;
-  else if (strcmp(arg, "ACS712-20") == 0 || strcmp(arg, "acs712-20") == 0)
-    return 0.1;
-  else if (strcmp(arg, "ACS712-30") == 0 || strcmp(arg, "acs712-30") == 0)
-    return 0.66;
-  else
-    return atof(arg);
-}
-
-
 PowerSensor::PowerSensor *getPowerSensor(std::string device)
 {
   if (device.empty())
@@ -84,7 +71,6 @@ void print()
     }
 
     std::cout << "sensor " << sensor << " (" << sensorType << "): "
-      "Pair ID: " << (int) powerSensor->getPairId(sensor) << ", "
       "type: " << type << ", "
       "Vref: " << powerSensor->getVref(sensor) << " V, "
       "Slope: " << powerSensor->getSlope(sensor) << " " << unit << " / V, "
@@ -107,7 +93,6 @@ void usage(char *argv[])
   std::cerr << "-h prints this help" << std::endl;
   std::cerr << "-d selects the device (default: /dev/ttyACM0)" << std::endl;
   std::cerr << "-s selects the sensor (0-" << PowerSensor::MAX_SENSORS << ")" << std::endl;
-  std::cerr << "-i sets the sensor pair (0-" << PowerSensor::MAX_PAIRS << ")" << std::endl;
   std::cerr << "-t sets the sensor type, (valid types TBD)" << std::endl;
   std::cerr << "-v sets the reference voltage level" << std::endl;
   std::cerr << "-n set the slope" << std::endl;
@@ -132,11 +117,6 @@ int main(int argc, char *argv[])
       // sensor select
       case 's':
         sensor = selectSensor((unsigned) atoi(optarg));
-        break;
-
-      // sensor pair
-      case 'i':
-        getPowerSensor(device)->setPairId(sensor, atoi(optarg));
         break;
 
       // sensor type

--- a/host/src/sensors.cc
+++ b/host/src/sensors.cc
@@ -21,7 +21,6 @@ namespace PowerSensor {
     setType(eeprom.type);
     setVref(eeprom.vref);
     setSlope(eeprom.slope);
-    setPairId(eeprom.pairId);
     setInUse(eeprom.inUse);
 
     reset();
@@ -33,7 +32,6 @@ namespace PowerSensor {
     strncpy(eeprom.type, type, sizeof type);
     eeprom.vref = vref;
     eeprom.slope = slope;
-    eeprom.pairId = pairId;
     eeprom.inUse = inUse;
 
     ssize_t retVal, bytesWritten = 0;
@@ -68,10 +66,6 @@ namespace PowerSensor {
 
   void PowerSensor::Sensor::setSlope(const float slope) {
     this->slope = slope;
-  }
-
-  void PowerSensor::Sensor::setPairId(const uint8_t pairId) {
-    this->pairId = pairId;
   }
 
   void PowerSensor::Sensor::setInUse(const bool inUse) {


### PR DESCRIPTION
Also removes pairID from EEPROM, as it was not used anywhere.
The assumption is that sensors 0 and 1 are pair 0, etc (`pair = sensor // 2`)