### PR TITLE
Add missing include of <array>, required in GCC 12

### DIFF
--- a/host/include/PowerSensor.hpp
+++ b/host/include/PowerSensor.hpp
@@ -2,6 +2,7 @@
 
 #include <inttypes.h>
 
+#include <array>
 #include <thread>
 #include <fstream>
 #include <queue>


### PR DESCRIPTION
Closes #72