### PR TITLE
Improve USB communication 

### DIFF
--- a/device/Makefile
+++ b/device/Makefile
@@ -9,7 +9,7 @@
 # For Black Pill F401CCU6
 BOARD =				BLACKPILL_F401CC
 DEVICE =            STMicroelectronics:stm32:GenF4
-FQBN =				$(DEVICE):pnum=$(BOARD),usb=$(USB),upload_method=dfuMethod
+FQBN =				$(DEVICE):pnum=$(BOARD),usb=$(USB),upload_method=dfuMethod,opt=o3std
 
 USB =				CDCgen
 


### PR DESCRIPTION
Improve USB communication stability and effective speed:
- make DMA interrupt prio higher than USB
- move USB comm from DMA IRQ handler to main loop
- User should increase transmit buffer size in STM32 code
- Compile with higher optimization level