### PR TITLE
Add optional TFT_BLUE define to support blue tab display

### DIFF
--- a/device/BLACKPILL_F401CC/PowerSensor/display.cpp
+++ b/device/BLACKPILL_F401CC/PowerSensor/display.cpp
@@ -23,7 +23,11 @@ void initDisplay() {
   SPI_3.begin();
   tft.initR(INITR_GREENTAB);
   tft.setRotation(3);
+#ifdef TFT_BLUE
+  tft.invertDisplay(false);
+#else
   tft.invertDisplay(true);
+#endif
   tft.fillScreen(ST77XX_BLACK);
   analogWrite(TFT_BLK, 120);
 }

--- a/device/Makefile
+++ b/device/Makefile
@@ -16,7 +16,7 @@ USB =				CDCgen
 all: device
 
 device:
-	arduino-cli compile -e --fqbn $(FQBN) $(BOARD)/PowerSensor --libraries $(BOARD)/PowerSensor/Libraries
+	arduino-cli compile -e --fqbn $(FQBN) $(BOARD)/PowerSensor --libraries $(BOARD)/PowerSensor/Libraries --build-property compiler.cpp.extra_flags=$(FLAGS)
 
 upload: device
 	arduino-cli upload $(OPT) --fqbn $(FQBN) -i $(BOARD)/PowerSensor/build/$(subst :,.,$(DEVICE))/PowerSensor.ino.bin


### PR DESCRIPTION
Compile with `make upload FLAGS=-DTFT_BLUE` for blue tab displays.
Closes #95 