### PR TITLE
Updates for F411

### DIFF
--- a/.github/workflows/build_device.yml
+++ b/.github/workflows/build_device.yml
@@ -16,12 +16,12 @@ jobs:
       matrix:
         os: ["ubuntu-22.04"]
         device: ["F401", "F411", "F407"]
-        # test other OS for one device type
+        # test other OS for default device type
         include:
           - os: "macos-11"
-            device: "F401"
+            device: "F411"
           - os: "windows-latest"
-            device: "F401"
+            device: "F411"
     steps:
     - uses: actions/checkout@v3
       with:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PowerSensor3 is a tool that measures the instantaneous power consumption of PCIe
 ## Hardware
 PowerSensor3 uses a modular hardware design with a base PCB containing a microcontroller and optionally a display, and up to four plug-in sensor boards. The PCB design, developed using KiCAD, is openly available [here](https://git.astron.nl/RD/powersensor3).
 
-The default configuration of PowerSensor3 is an STM32F401 Black Pill microcontroller with SPI-based display, and up to four pairs of voltage and current sensors. Typical usage with a GPU is to measure both the 3.3 V and 12 V power through the PCIe slot, and up to two ATX 12 V connections directly from the power supply to the GPU. The microcontroller interprets the sensor data and reports the power measurements via USB to the host.
+The default configuration of PowerSensor3 is an STM32F411 Black Pill microcontroller with SPI-based display, and up to four pairs of voltage and current sensors. Typical usage with a GPU is to measure both the 3.3 V and 12 V power through the PCIe slot, and up to two ATX 12 V connections directly from the power supply to the GPU. The microcontroller interprets the sensor data and reports the power measurements via USB to the host.
 
 ## Disclaimer
 You are about to modify electronic circuits.  Improperly connecting wires can be dangerous and may damage computer equipment.  We are not responsible for any harm or damage that might occur.  Make sure that you understand very well how all cables should be connected.  Do not install this tool if you are not absolutely sure what you are doing.
@@ -28,9 +28,9 @@ You are about to modify electronic circuits.  Improperly connecting wires can be
 ## Further reading
 Altering the firmware of the device could be necessary in certain use cases. For this please refer to the following documents:
 
-* [STM32F401CCU6 BlackPill overview](https://stm32-base.org/boards/STM32F401CCU6-WeAct-Black-Pill-V1.2.html)
-* [STM32F401xB/C Datasheet](https://www.st.com/resource/en/datasheet/stm32f401cc.pdf)
-* [STM32F401xB/C/D/E Reference manual](https://www.st.com/resource/en/reference_manual/rm0368-stm32f401xbc-and-stm32f401xde-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
+* [STM32F401CCU6 BlackPill overview](https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0)
+* [STM32F401xB/C Datasheet](https://www.st.com/resource/en/datasheet/stm32f411ce.pdf)
+* [STM32F401xB/C/D/E Reference manual](https://www.st.com/resource/en/reference_manual/rm0383-stm32f411xce-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
 * [STM32F2/4/7 DMA programming manual](https://www.st.com/resource/en/application_note/dm00046011-using-the-stm32f2-stm32f4-and-stm32f7-series-dma-controller-stmicroelectronics.pdf)
 * [STM32F40x/STM3241x EEPROM emulation in flash](https://www.st.com/resource/en/application_note/an3969-eeprom-emulation-in-stm32f40xstm32f41x-microcontrollers-stmicroelectronics.pdf)
 

--- a/device/Makefile
+++ b/device/Makefile
@@ -1,5 +1,5 @@
 # Makefile for device code
-DEV ?= F401
+DEV ?= F411
 
 ifeq ($(DEV), F401)
 # BLack Pill F401CCU6

--- a/docs/INSTALLATION_DEVICE.md
+++ b/docs/INSTALLATION_DEVICE.md
@@ -14,7 +14,7 @@ ATX 8-pin   | 12          | 150               | 12.5
 After connecting all relevant power cable, connect the microcontroller to a USB port on the host. After making sure that everything is connected correctly, turn on the host system.
 
 ## Building the firmware
-We provide pre-built binaries [here](https://github.com/nlesc-recruit/PowerSensor3/releases) for default configurations using either an STM32F401 or STM32F407 microcontrollers. For non-default settings or other customizations, the firmware can be built with the Arduino toolkit as outlined in this section. Note that the pre-built binaries use a modified USB transmit buffer size, see the [USB Buffer size](#usb-buffer-size) section.
+We provide pre-built binaries [here](https://github.com/nlesc-recruit/PowerSensor3/releases) for default configurations using either any of the supported microcontrollers. For non-default settings or other customizations, the firmware can be built with the Arduino toolkit as outlined in this section. Note that the pre-built binaries use a modified USB transmit buffer size, see the [USB Buffer size](#usb-buffer-size) section.
 
 
 The firmware is dependent on a few Arduino tools, these should be installed before continueing. First the [arduino-cli](https://github.com/arduino/arduino-cli) package can be installed on Linux via:
@@ -46,7 +46,7 @@ Then run the following command in the device folder to build the firmware with d
 
     make device
 
-For an STM32F401 Black Pill, the fimware will be written to `PowerSensor/build/STMicroelectronics.stm32.GenF4/PowerSensor.ino.bin`
+For an STM32F401 or STM32F411 Black Pill, the fimware will be written to `PowerSensor/build/STMicroelectronics.stm32.GenF4/PowerSensor.ino.bin`, for the STM32F407 Discovery, the file location is `PowerSensor/build/STMicroelectronics.stm32.Disco/PowerSensor.ino.bin`.
 
 ### Uploading the firmware
 First make sure the device is booted in DFU mode. This is typically achieved by holding down the BOOT0 button and pressing the RESET button. Confirm that the device has entered DFU mode with either:
@@ -70,9 +70,9 @@ If the firmware is uploaded successfully, the device will be reset and start run
 There are several options available to customize the firmware build. These options can be append to the `make device` and `make upload` commands.
 
 ## Target microcontroller
-We provided a flag to set whether the firmware is built for an STM32F401 (default) or STM32F407 microcontroller.  
+A flag is provided to set whether the firmware is built for an STM32F401, STM32F411 (default) or STM32F407 microcontroller.  
 Option name: DEV  
-Allowed values: F401, F407  
+Allowed values: F401, F411, F407  
 Example:
 
     make upload DEV="F401"

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -76,7 +76,7 @@ namespace PowerSensor3 {
   /**
    * @brief Construct a new Power Sensor:: Power Sensor object
    *
-   * @param device path to device, e.g. /dev/ttyACM1
+   * @param device path to device, e.g. /dev/ttyACM0
    */
   PowerSensor::PowerSensor(std::string device):
     fd(openDevice(device)),
@@ -128,7 +128,7 @@ namespace PowerSensor3 {
   /**
    * @brief Connect to PowerSensor device
    *
-   * @param device path to device, e.g. /dev/ttyACM1
+   * @param device path to device, e.g. /dev/ttyACM0
    * @return int file descriptor
    */
   int PowerSensor::openDevice(std::string device) {

--- a/host/src/psrun.cc
+++ b/host/src/psrun.cc
@@ -14,7 +14,7 @@ void usage(char *argv[]) {
 
 
 int main(int argc, char *argv[]) {
-  std::string device = "/dev/ttyACM1";
+  std::string device = "/dev/ttyACM0";
   std::string dumpFileName;
   int sensorPair  = -1;
 


### PR DESCRIPTION
- Update docs for F411
- Make F411 default device
- Ensure default device path is ttyACM0 everywhere, some places still had ttyACM1