### PR TITLE
Add sensor pair names to `State` returned by `PowerSensor.read()`

### DIFF
--- a/host/include/PowerSensor.hpp
+++ b/host/include/PowerSensor.hpp
@@ -58,13 +58,13 @@ class PowerSensor {
 
     void writeSensorsToEEPROM();
     void setType(unsigned int sensorID, const std::string type);
-    void setPairName(unsigned int sensorID, const std::string pairName);
+    void setPairName(unsigned int pairID, const std::string pairName);
     void setVref(unsigned int sensorID, const float vref);
     void setSensitivity(unsigned int sensorID, const float slope);
     void setInUse(unsigned int sensorID, const bool inUse);
 
     std::string getType(unsigned int sensorID) const;
-    std::string getPairName(unsigned int sensorID) const;
+    std::string getPairName(unsigned int pairID) const;
     float getVref(unsigned int sensorID) const;
     float getSensitivity(unsigned int sensorID) const;
     bool getInUse(unsigned int sensorID) const;

--- a/host/include/PowerSensor.hpp
+++ b/host/include/PowerSensor.hpp
@@ -30,6 +30,8 @@ struct State {
   std::array<double, MAX_PAIRS> current;
   /** @brief Voltage, per sensor */
   std::array<double, MAX_PAIRS> voltage;
+  /** @brief Name, per sensor */
+  std::array<std::string, MAX_PAIRS> name;
   /** @brief Timestamp */
   double timeAtRead;
 };
@@ -143,6 +145,7 @@ class PowerSensor {
       double timeAtLastMeasurement;
       double consumedEnergy;
       bool inUse;
+      std::string name;
     } sensorPairs[MAX_PAIRS];
 };
 

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -562,13 +562,19 @@ namespace PowerSensor3 {
   }
 
   /**
-   * @brief Get sensor pair name of given sensor
+   * @brief Get name of given sensor pair
    *
-   * @param sensorID
+   * @param pairID
    * @return std::string
    */
-  std::string PowerSensor::getPairName(unsigned int sensorID) const {
-    return sensors[sensorID].pairName;
+  std::string PowerSensor::getPairName(unsigned int pairID) const {
+    checkPairID(pairID);
+    // warn if sensor pair names of the two sensors are not equal
+    if (sensors[2 * pairID].pairName != sensors[2 * pairID + 1].pairName) {
+      std::cerr << "Sensor pair names of pair " << pairID << " do not match, use psconfig to correct the values. "
+        "Returning value of first sensor" << std::endl;
+    }
+    return sensors[2 * pairID].pairName;
   }
 
   /**
@@ -612,13 +618,16 @@ namespace PowerSensor3 {
   }
 
   /**
-   * @brief Set sensor pair name of given sensor
+   * @brief Set sensor pair name of given sensor pair
    *
-   * @param sensorID
+   * @param pairID
    * @param pairName
    */
-  void PowerSensor::setPairName(unsigned int sensorID, const std::string pairName) {
-    sensors[sensorID].setPairName(pairName);
+  void PowerSensor::setPairName(unsigned int pairID, const std::string pairName) {
+    checkPairID(pairID);
+    // set name of both sensors of the pair
+    sensors[2 * pairID].setPairName(pairName);
+    sensors[2 * pairID + 1].setPairName(pairName);
   }
 
   /**

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -117,6 +117,7 @@ namespace PowerSensor3 {
       state.consumedEnergy[pairID] = sensorPairs[pairID].consumedEnergy;
       state.current[pairID] = sensorPairs[pairID].currentAtLastMeasurement;
       state.voltage[pairID] = sensorPairs[pairID].voltageAtLastMeasurement;
+      state.name[pairID] = sensorPairs[pairID].name;
       // Note: timeAtLastMeasurement is the same for each _active_ sensor pair
       if (sensorPairs[pairID].inUse) {
         state.timeAtRead = sensorPairs[pairID].timeAtLastMeasurement;
@@ -264,7 +265,7 @@ namespace PowerSensor3 {
       sensorPairs[pairID].consumedEnergy = 0;
       sensorPairs[pairID].currentAtLastMeasurement = 0;
       sensorPairs[pairID].voltageAtLastMeasurement = 0;
-
+      sensorPairs[pairID].name = getPairName(pairID);
 
       bool currentSensorActive = sensors[2*pairID].inUse;
       bool voltageSensorActive = sensors[2*pairID+1].inUse;

--- a/host/src/psconfig.cc
+++ b/host/src/psconfig.cc
@@ -146,9 +146,13 @@ void print() {
       factor = 1;
     }
 
+    // get string values before printing the output so any warnings are readable
+    std::string type = powerSensor->getType(sensor);
+    std::string pairName = powerSensor->getPairName(sensor / 2);  // div by 2 to convert to pair ID
+
     std::cout << "sensor " << sensor << " (" << sensorType << "): "
-      "type: " << powerSensor->getType(sensor) << ", "
-      "name: " << powerSensor->getPairName(sensor) << ", "
+      "type: " << type << ", "
+      "name: " << pairName << ", "
       "Vref: " << powerSensor->getVref(sensor) << " V, " <<
       sensitivityName << ": " << factor * powerSensor->getSensitivity(sensor) << unit << ", "
       "Status: " << (powerSensor->getInUse(sensor) ? "on" : "off") << std::endl;
@@ -172,7 +176,8 @@ void usage(char *argv[]) {
   std::cerr << "-s selects the sensor (0-" << PowerSensor3::MAX_SENSORS << ")" << std::endl;
   std::cerr << "-t sets the sensor type. This also sets the sensitivity to the default value if "
                "the sensor is of a type known to this programme (see list at the bottom of this help)." << std::endl;
-  std::cerr << "-m sets the sensor pair name." << std::endl;
+  std::cerr << "-m sets the sensor pair name. Setting this for either of the sensors of a pair "
+               "sets the same pair name for both sensors" << std::endl;
   std::cerr << "-v sets the reference voltage level" << std::endl;
   std::cerr << "-a automatically calibrate vref of the current sensor. "
                "The input to the sensor must be zero volt or ampere" << std::endl;
@@ -218,13 +223,9 @@ int main(int argc, char *argv[]) {
 
       // sensor pair name
       case 'm':
-        getPowerSensor(device)->setPairName(sensor, optarg);
-        // ensure to set same pair name for both the current and voltage sensor
-        if ((sensor % 2) == 0) {
-          getPowerSensor(device)->setPairName(sensor + 1, optarg);
-        } else {
-          getPowerSensor(device)->setPairName(sensor - 1, optarg);
-        }
+        // sensor / 2 corresponds to the index of the sensor _pair_
+        getPowerSensor(device)->setPairName(sensor / 2, optarg);
+        doWriteConfig = true;
         break;
 
       // sensor auto calibration of reference voltage

--- a/python/PyPowerSensor.cc
+++ b/python/PyPowerSensor.cc
@@ -30,5 +30,6 @@ PYBIND11_MODULE(powersensor, m) {
       "Total energy consumption (J), counted from initialization of PowerSensor device")
     .def_readonly("current", &PowerSensor3::State::current, "Current current (A)")
     .def_readonly("voltage", &PowerSensor3::State::voltage, "Current voltage (V)")
+    .def_readonly("name", &PowerSensor3::State::name, "Name")
     .def_readonly("time_at_read", &PowerSensor3::State::timeAtRead, "Current time (s)");
 }


### PR DESCRIPTION
So the user can access the sensor pair names by pairID if they want.

Also forces the same name for both sensors of the same pair by moving this functionality from `psconfig` to the `PowerSensor` library.