### PR TITLE
Avoid microcontroller getting stuck in an infinite loop 

### DIFF
--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -131,9 +131,10 @@ void JumpToBootloader() {
 inline void wait_for_host(int nbytes) {
   unsigned long tstart = millis();
   while (Serial.read() < nbytes) {
-      if ((millis() - tstart) > TIMEOUT);
-      // host is taking too long, assume connection broken and reset device
-      NVIC_SystemReset();
+      if ((millis() - tstart) > TIMEOUT) {
+        // host is taking too long, assume connection broken and reset device
+        NVIC_SystemReset();
+      }
     }
 }
 


### PR DESCRIPTION
This can happen if the host stops sending data due to e.g. a crash.

The loops waiting for data from the host now have a timeout (default 2s), after which the device is reset if nothing is received.