### PR TITLE
Improve marker functionality and related dumpfile issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ lib/
 obj/
 *.so*
 
-build/
+build*/
 testing/
 
 # documentation output

--- a/device/Makefile
+++ b/device/Makefile
@@ -17,7 +17,7 @@ BOARD =			DISCO_F407VG
 DEVICE =        STMicroelectronics:stm32:Disco
 FQBN =          $(DEVICE):pnum=$(BOARD),usb=CDCgen,upload_method=dfuMethod,xusb=FS,opt=o3std
 else
-$(error Unknown device $(DEV), allowed devices are F401 (default), F411, and F407)
+$(error Unknown device $(DEV), allowed devices are F401, F411 (default), and F407)
 endif
 
 

--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -84,7 +84,7 @@ uint8_t serialData[(SENSORS + 1) * 2];  // 16b per sensor and 16b for timestamp
 bool sendData = false;
 bool streamValues = false;
 bool sendSingleValue = false;
-bool sendMarkerNext = false;
+uint32_t sendMarkers = 0;
 bool allSensorsInactive = false;
 
 // include device-specific code for setting up the ADC and DMA
@@ -233,7 +233,7 @@ void serialEvent() {
       break;
     case 'M':
       // marker character, places a marker in the output file
-      sendMarkerNext = true;
+      sendMarkers++;
       break;
     case 'I':
       // Send single set of sensor values. does nothing if streaming is enabled

--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -253,8 +253,8 @@ void serialEvent() {
       // in demo mode the display is always enabled so no need to reinitialize it here
       // if streaming was enabled, first wait until all markers are sent
       if (streamValues) {
-        while(sendMarkers > 0) delay(1);
-        while(!sendData) delay(1);
+        while (sendMarkers > 0) delay(1);
+        while (!sendData) delay(1);
       }
       streamValues = false;
 #if !defined NODISPLAY && !defined DEMO
@@ -266,8 +266,8 @@ void serialEvent() {
       // Shutdown and unpause display, shuts off IO thread on host
       // if streaming was enabled, first wait until all markers are sent
       if (streamValues) {
-        while(sendMarkers > 0) delay(1);
-        while(!sendData) delay(1);
+        while (sendMarkers > 0) delay(1);
+        while (!sendData) delay(1);
       }
 #ifndef NODISPLAY
       displayPaused = false;

--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -251,6 +251,11 @@ void serialEvent() {
     case 'T':
       // Disable streaming of data and unpause display
       // in demo mode the display is always enabled so no need to reinitialize it here
+      // if streaming was enabled, first wait until all markers are sent
+      if (streamValues) {
+        while(sendMarkers > 0) delay(1);
+        while(!sendData) delay(1);
+      }
       streamValues = false;
 #if !defined NODISPLAY && !defined DEMO
       displayPaused = false;
@@ -259,6 +264,11 @@ void serialEvent() {
       break;
     case 'X':
       // Shutdown and unpause display, shuts off IO thread on host
+      // if streaming was enabled, first wait until all markers are sent
+      if (streamValues) {
+        while(sendMarkers > 0) delay(1);
+        while(!sendData) delay(1);
+      }
 #ifndef NODISPLAY
       displayPaused = false;
       displayInitialValues();

--- a/device/PowerSensor/device_specific/BLACKPILL_F401CC_F411CE.hpp
+++ b/device/PowerSensor/device_specific/BLACKPILL_F401CC_F411CE.hpp
@@ -124,6 +124,12 @@ extern "C" void DMA2_Stream0_IRQHandler() {
       // store in sensorValues for display purposes
       sensorLevels[i] = level;
 #endif
+      // determine whether or not to send marker
+      // marker is always sent with sensor 0
+      bool sendMarkerNext = (i == 0) && (sendMarkers > 0);
+      if (sendMarkerNext) {
+        sendMarkers--;
+      }
       // add metadata to remaining bits: 2 bytes available with 10b sensor value
       // First byte: 1 iii aaaa
       // where iii is the sensor id, a are the upper 4 bits of the level

--- a/device/PowerSensor/device_specific/DISCO_F407VG.hpp
+++ b/device/PowerSensor/device_specific/DISCO_F407VG.hpp
@@ -118,6 +118,12 @@ extern "C" void DMA2_Stream0_IRQHandler() {
     // store in sensorValues for display purposes
     sensorLevels[i] = level;
 #endif
+    // determine whether or not to send marker
+    // marker is always sent with sensor 0
+    bool sendMarkerNext = (i == 0) && (sendMarkers > 0);
+    if (sendMarkerNext) {
+      sendMarkers--;
+    }
     // add metadata to remaining bits: 2 bytes available with 10b sensor value
     // First byte: 1 iii aaaa
     // where iii is the sensor id, a are the upper 4 bits of the level

--- a/host/include/PowerSensor.hpp
+++ b/host/include/PowerSensor.hpp
@@ -55,7 +55,6 @@ class PowerSensor {
 
     void dump(const std::string dumpFileName);  // dumpFileName == 0 --> stop dumping
     void mark(char name);
-    void mark(const State &startState, const State &stopState, const std::string name = 0, unsigned int tag = 0) const;
     void reset(bool dfuMode);
 
     void writeSensorsToEEPROM();

--- a/host/include/PowerSensor.hpp
+++ b/host/include/PowerSensor.hpp
@@ -82,6 +82,7 @@ class PowerSensor {
     int openDevice(std::string device);
     std::queue<char> markers;
     void writeMarker();
+    void waitForMarkers(int timeout=500);
 
     void initializeSensorPairs();
     void updateSensorPairs();

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -378,16 +378,14 @@ void PowerSensor::mark(const State &startState, const State &stopState, std::str
  * @param timeout maximum waiting time in milliseconds
  */
 void PowerSensor::waitForMarkers(int timeout) {
-  std::chrono::duration<double, std::milli> elapsed;
   auto tstart = std::chrono::high_resolution_clock::now();
   while (markers.size() != 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    elapsed = std::chrono::high_resolution_clock::now() - tstart;
+    auto elapsed = std::chrono::high_resolution_clock::now() - tstart;
     if (elapsed.count() > timeout) {
         break;
     }
   }
-  std::cout << "Marker waiting time: " << elapsed.count() << std::endl;
 }
 
 /**

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -356,23 +356,6 @@ void PowerSensor::writeMarker() {
 }
 
 /**
- * @brief Write custom marker to dump file
- *
- * @param startState State used to get start time
- * @param stopState State used to get end time
- * @param name name of the marker (string)
- * @param tag id of the marker (int)
- */
-void PowerSensor::mark(const State &startState, const State &stopState, std::string name, unsigned int tag) const {
-  if (dumpFile != nullptr) {
-    std::unique_lock<std::mutex> lock(dumpFileMutex);
-    *dumpFile << "M " << elapsedSeconds(startTime, startState.timeAtRead) << ' ' \
-      << elapsedSeconds(startTime, stopState.timeAtRead) << ' ' \
-      << tag << " \"" << name << '"' << std::endl;
-  }
-}
-
-/**
  * @brief Wait for all markers to be written to the dump file
  *
  * @param timeout maximum waiting time in milliseconds


### PR DESCRIPTION
Updates in host library:

- Avoid segfaults by avoiding writing when a dumpfile no longer exists
- Wait for markers to finish writing when 1. Stopping a dump, 2. stopping the IO thread.
- Remove unused extended mark function that does not sync with device

The default timeout when waiting for markers is 500 ms. ~~Still, sometimes the last marker is not written. Even with a 5s timeout this happens. To be debugged further in firmware: verify the marker is actually being sent. Perhaps the boolean flag in the firmware (should we send a marker?) can be replaced by a counter to avoid missing markers in quick succession.~~

Firmware updates:
- Count how many markers should still be sent, instead of using a boolean. This avoids missing a second marker when request very close in time to the first one.
- When receiving a stop signal (T or X), first wait for any markers to be sent