### PR TITLE
Let device send only FW version itself, not including prefix nor newline

### DIFF
--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -278,12 +278,9 @@ void serialEvent() {
       break;
     case 'V':
       // Send firmware version in human-readable format
-      Serial.print("Firmware version: ");
-#ifdef DEMO
       Serial.print(VERSION);
-      Serial.println("-DEMO");
-#else
-      Serial.println(VERSION);
+#ifdef DEMO
+      Serial.print("-DEMO");
 #endif
       break;
     case 'Z':

--- a/host/src/psconfig.cc
+++ b/host/src/psconfig.cc
@@ -127,8 +127,7 @@ void autoCalibrate() {
 
 
 void print() {
-  // firmware version
-  std::cout << powerSensor->getVersion() << std::endl;
+  std::cout << "Device firmware version: " << powerSensor->getVersion() << std::endl;
 
   PowerSensor3::State startState, stopState;
 

--- a/host/src/psinfo.cc
+++ b/host/src/psinfo.cc
@@ -18,8 +18,7 @@ void getPowerSensor(std::string device) {
 
 
 void printInfo() {
-  // firmware version
-  std::cout << powerSensor->getVersion() << std::endl;
+  std::cout << "Device firmware version: " << powerSensor->getVersion() << std::endl;
 
   PowerSensor3::State state = powerSensor->read();
 


### PR DESCRIPTION
psconfig/psinfo now print the prefix

Closes #181 