### PR TITLE
Re-add sending newline in FW version from device; remove it on the host

### DIFF
--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -278,9 +278,11 @@ void serialEvent() {
       break;
     case 'V':
       // Send firmware version in human-readable format
-      Serial.print(VERSION);
 #ifdef DEMO
-      Serial.print("-DEMO");
+      Serial.print(VERSION);
+      Serial.println("-DEMO");
+#else
+      Serial.println(VERSION);
 #endif
       break;
     case 'Z':

--- a/host/src/PowerSensor.cc
+++ b/host/src/PowerSensor.cc
@@ -596,6 +596,8 @@ std::string PowerSensor::getVersion() {
       c = readCharFromDevice();
       version += c;
   }
+  // remove newline from version string
+  version.pop_back();
   startIOThread();
   return version;
 }


### PR DESCRIPTION
In PR #183 I missed that the host uses the newline to determine when the entire version string has been received. The newline is re-added to the device, and removed on the host before returning the string.