### PR TITLE
Decrease missed packets when using marker

### DIFF
--- a/device/PowerSensor/PowerSensor.ino
+++ b/device/PowerSensor/PowerSensor.ino
@@ -411,6 +411,7 @@ void setup() {
 
 void loop() {
   if (sendData) {
+    sendData = false;
     // copy serialData to avoid overwrite by next values in IRQ handler
     uint8_t serialDataToSend[sizeof(serialData)];
     memcpy(serialDataToSend, serialData, sizeof(serialData));
@@ -421,7 +422,6 @@ void loop() {
       sendMarkers--;
     }
     Serial.write(serialDataToSend, sizeof(serialDataToSend));
-    sendData = false;
   }
   // check for serial events
   serialEvent();


### PR DESCRIPTION
`sendData` is now set to false as quickly as possible so it can be set to true again by the interrupt handler while sending data is still in progress